### PR TITLE
update modules to use module name logging

### DIFF
--- a/kubemq/commandquery/lowlevel/initiator.py
+++ b/kubemq/commandquery/lowlevel/initiator.py
@@ -24,6 +24,8 @@ from kubemq.grpc import Empty
 from kubemq.basic.grpc_client import GrpcClient
 from kubemq.commandquery.response import Response
 
+logger = logging.getLogger(__name__)
+
 
 class Initiator(GrpcClient):
     """Represents the instance that is responsible to send requests to the kubemq."""
@@ -41,7 +43,7 @@ class Initiator(GrpcClient):
     def ping(self):
         """ping check connection to the kubemq"""
         ping_result = self.get_kubemq_client().Ping(Empty())
-        logging.debug("Initiator KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
+        logger.debug("Initiator KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
         return ping_result
 
     def send_request_async(self, request, handler):
@@ -55,7 +57,7 @@ class Initiator(GrpcClient):
             call_future = self.get_kubemq_client().SendRequest.future(inner_request, None, self._metadata)
             call_future.add_done_callback(process_response)
         except Exception as e:
-            logging.exception("Grpc Exception in send_request_async'%s'" % (e))
+            logger.exception("Grpc Exception in send_request_async'%s'" % (e))
             raise
 
     def send_request(self, request):
@@ -65,5 +67,5 @@ class Initiator(GrpcClient):
             inner_response = self.get_kubemq_client().SendRequest(inner_request, None, self._metadata)
             return Response(inner_response)
         except Exception as e:
-            logging.exception("Grpc Exception in send_request:'%s'" % (e))
+            logger.exception("Grpc Exception in send_request:'%s'" % (e))
             raise

--- a/kubemq/events/lowlevel/sender.py
+++ b/kubemq/events/lowlevel/sender.py
@@ -25,6 +25,8 @@ from kubemq.basic.grpc_client import GrpcClient
 from kubemq.events.lowlevel.event import Event
 from kubemq.events.result import Result
 
+logger = logging.getLogger(__name__)
+
 
 class Sender(GrpcClient):
     """Represents the instance that is responsible to send events to the kubemq."""
@@ -48,7 +50,7 @@ class Sender(GrpcClient):
             if result:
                 return Result(inner_result=result)
         except Exception as e:
-            logging.exception(
+            logger.exception(
                 "Sender received 'Result': Error:'%s'" % (
                     e
                 ))
@@ -64,7 +66,7 @@ class Sender(GrpcClient):
             for response in responses:
                 if response_handler:
                     result = Result(response)
-                    logging.debug(
+                    logger.debug(
                         "Sender received 'Result': EventID:'%s', Sent:'%s', Error:'%s'" % (
                             result.event_id,
                             result.sent,
@@ -72,7 +74,7 @@ class Sender(GrpcClient):
                         ))
                     response_handler(result)
         except Exception as e:
-            logging.exception(
+            logger.exception(
                 "Sender received 'Result': Error:'%s'" % (
                     e
                 ))
@@ -81,5 +83,5 @@ class Sender(GrpcClient):
     def ping(self):
         """ping check connection to the kubemq"""
         ping_result = self.get_kubemq_client().Ping(Empty())
-        logging.debug("event sender KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
+        logger.debug("event sender KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
         return ping_result

--- a/kubemq/events/subscriber.py
+++ b/kubemq/events/subscriber.py
@@ -7,6 +7,7 @@ from kubemq.events.event_receive import EventReceive
 from kubemq.subscription import SubscribeType, EventsStoreType
 from kubemq.tools.listener_cancellation_token import ListenerCancellationToken
 
+logger = logging.getLogger(__name__)
 
 class Subscriber(GrpcClient):
 
@@ -24,7 +25,7 @@ class Subscriber(GrpcClient):
     def ping(self):
         """ping check connection to the kubemq"""
         ping_result = self.get_kubemq_client().Ping(Empty())
-        logging.debug("event subscriber KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
+        logger.debug("event subscriber KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
         return ping_result
 
     def subscribe_to_events(self, subscribe_request, handler, error_handler,
@@ -59,7 +60,7 @@ class Subscriber(GrpcClient):
                 while True:
                     event_receive = call.next()
 
-                    logging.info("Subscriber Received Event: EventID:'%s', Channel:'%s', Body:'%s Tags:%s'" % (
+                    logger.info("Subscriber Received Event: EventID:'%s', Channel:'%s', Body:'%s Tags:%s'" % (
                         event_receive.EventID,
                         event_receive.Channel,
                         event_receive.Body,
@@ -69,19 +70,19 @@ class Subscriber(GrpcClient):
                     handler(EventReceive(event_receive))
             except grpc.RpcError as error:
                 if (listener_cancellation_token.is_cancelled):
-                    logging.info("Sub closed by listener request")
+                    logger.info("Sub closed by listener request")
                     error_handler(str(error))
                 else:
-                    logging.exception("Subscriber Received Error: Error:'%s'" % (error))
+                    logger.exception("Subscriber Received Error: Error:'%s'" % (error))
                     error_handler(str(error))
             except Exception as e:
-                logging.exception("Subscriber Received Error: Error:'%s'" % (e))
+                logger.exception("Subscriber Received Error: Error:'%s'" % (e))
                 error_handler(str(e))
 
         def check_sub_to_valid(listener_cancellation_token):
             while True:
                 if (listener_cancellation_token.is_cancelled):
-                    logging.info("Sub closed by listener request")
+                    logger.info("Sub closed by listener request")
                     call.cancel()
                     return
 

--- a/kubemq/queue/message_queue.py
+++ b/kubemq/queue/message_queue.py
@@ -35,6 +35,7 @@ from kubemq.queue.send_batch_message_result import \
 from kubemq.tools.id_generator import get_next_id as get_next_id
 from kubemq.queue.transaction import Transaction
 
+logger = logging.getLogger(__name__)
 
 class MessageQueue(GrpcClient):
     """Represents a MessageQueue pattern."""
@@ -78,7 +79,7 @@ class MessageQueue(GrpcClient):
             inner_response = self.get_kubemq_client().SendQueueMessage(inner_queue_message, metadata=self._metadata)
             return SendMessageResult(inner_response)
         except Exception as e:
-            logging.exception("Grpc Exception in send_queue_message_result:'%s'" % (e))
+            logger.exception("Grpc Exception in send_queue_message_result:'%s'" % (e))
             raise
 
     def send_queue_messages_batch(self, messages):
@@ -89,7 +90,7 @@ class MessageQueue(GrpcClient):
                 convert_queue_message_batch_request(id, to_queue_messages(messages, self)), metadata=self._metadata)
             return convert_from_queue_messages_batch_response(inner_response)
         except Exception as e:
-            logging.exception("Grpc Exception in send_queue_messages_batch:'%s'" % (e))
+            logger.exception("Grpc Exception in send_queue_messages_batch:'%s'" % (e))
             raise
 
     def receive_queue_messages(self, number_of_messages=None):
@@ -100,7 +101,7 @@ class MessageQueue(GrpcClient):
                 self.convert_to_receive_queue_messages_request(id, False, number_of_messages), metadata=self._metadata)
             return ReceiveMessagesResponse(inner_response)
         except Exception as e:
-            logging.exception("Grpc Exception in send_queue_messages:'%s'" % (e))
+            logger.exception("Grpc Exception in send_queue_messages:'%s'" % (e))
             raise
 
     def peek_queue_message(self, number_of_messages=None):
@@ -111,7 +112,7 @@ class MessageQueue(GrpcClient):
                 self.convert_to_receive_queue_messages_request(id, True, number_of_messages), metadata=self._metadata)
             return ReceiveMessagesResponse(inner_response)
         except Exception as e:
-            logging.exception("Grpc Exception in send_queue_messages_batch:'%s'" % (e))
+            logger.exception("Grpc Exception in send_queue_messages_batch:'%s'" % (e))
             raise
 
     def ack_all_queue_messages(self):
@@ -121,13 +122,13 @@ class MessageQueue(GrpcClient):
                 self.convert_to_ack_all_queue_message_request(), metadata=self._metadata)
             return AckAllMessagesResponse(inner_response)
         except Exception as e:
-            logging.exception("Grpc Exception in ack_all_queue_messages:'%s'" % (e))
+            logger.exception("Grpc Exception in ack_all_queue_messages:'%s'" % (e))
             raise
 
     def ping(self):
         """ping check connection to the kubemq"""
         ping_result = self.get_kubemq_client().Ping(Empty())
-        logging.debug("MessageQueue KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
+        logger.debug("MessageQueue KubeMQ address:%s ping result:%s'" % (self._kubemq_address, ping_result))
         return ping_result
 
     def convert_to_ack_all_queue_message_request(self):

--- a/kubemq/queue/transaction.py
+++ b/kubemq/queue/transaction.py
@@ -37,6 +37,8 @@ from kubemq.queue.transaction_messages import create_stream_queue_message_reject
 from kubemq.queue.transaction_messages import create_stream_queue_message_resend_request
 from kubemq.tools.id_generator import get_next_id
 
+logger = logging.getLogger(__name__)
+
 
 class ControlMessages(enum.Enum):
     CLOSE_STREAM = enum.auto()
@@ -78,7 +80,7 @@ class Transaction(GrpcClient):
 
             return TransactionMessagesResponse(next(self.inner_stream))
         except Exception as e:
-            logging.exception("Exception in receive: '%s'" % e)
+            logger.exception("Exception in receive: '%s'" % e)
             raise
 
     def ack_message(self, msg_sequence):
@@ -92,7 +94,7 @@ class Transaction(GrpcClient):
 
             return TransactionMessagesResponse(next(self.inner_stream))
         except Exception as e:
-            logging.exception("Exception in ack:'%s'" % e)
+            logger.exception("Exception in ack:'%s'" % e)
             raise
 
     def rejected_message(self, msg_sequence):
@@ -106,7 +108,7 @@ class Transaction(GrpcClient):
 
                 return TransactionMessagesResponse(next(self.inner_stream))
             except Exception as e:
-                logging.exception("Exception in reject:'%s'" % e)
+                logger.exception("Exception in reject:'%s'" % e)
                 raise
 
     def extend_visibility(self, visibility_seconds):
@@ -121,7 +123,7 @@ class Transaction(GrpcClient):
 
                 return TransactionMessagesResponse(next(self.inner_stream))
             except Exception as e:
-                logging.exception("Exception in Extend:'%s'" % e)
+                logger.exception("Exception in Extend:'%s'" % e)
                 raise
 
     def resend(self, queue_name):
@@ -135,7 +137,7 @@ class Transaction(GrpcClient):
 
                 return TransactionMessagesResponse(next(self.inner_stream))
             except Exception as e:
-                logging.exception("Exception in resend:'%s'" % e)
+                logger.exception("Exception in resend:'%s'" % e)
                 raise
 
     def modify(self, msg):
@@ -156,7 +158,7 @@ class Transaction(GrpcClient):
 
                 return TransactionMessagesResponse(next(self.inner_stream))
             except Exception as e:
-                logging.exception("Exception in resend:'%s'" % e)
+                logger.exception("Exception in resend:'%s'" % e)
                 raise
 
     def open_stream(self):
@@ -196,7 +198,7 @@ class Transaction(GrpcClient):
                 self.inner_stream.cancel()
                 return True
             else:
-                logging.error("Stream is closed")
+                logger.error("Stream is closed")
                 return False
 
     def check_call_is_in_transaction(self):


### PR DESCRIPTION
Hi,

This PR corrects the use of the root logger in the python modules allowing consumers of your code to set their own log levels on your modules and have better logging control overall for their own applications. 

The way this was written before, logs from these libraries were creating default log handlers and logging via the root logger.  

In my use case where logs are set up with specialized handlers, I was getting multiple logs in the console with no way to disable the logger in these libraries. This change should allow that control as well as allow users to identify which modules are throwing errors/creating logs. 

Please let me know if there is anything I need to do as a more formal process. I did not see a contribution guide in the repo. 

Cheers